### PR TITLE
feat(app): scaffold Next.js + Electron app shell for Mint Speech

### DIFF
--- a/app/api/edgetts/route.ts
+++ b/app/api/edgetts/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json({ message: 'Edge TTS proxy not implemented yet.' }, { status: 501 });
+}

--- a/app/api/elevenlabs/route.ts
+++ b/app/api/elevenlabs/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json({ message: 'ElevenLabs proxy not implemented yet.' }, { status: 501 });
+}

--- a/app/api/gemini/route.ts
+++ b/app/api/gemini/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json({ message: 'Gemini TTS proxy not implemented yet.' }, { status: 501 });
+}

--- a/app/api/roadmap/route.ts
+++ b/app/api/roadmap/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ message: 'Roadmap fetcher not implemented yet.' }, { status: 501 });
+}

--- a/app/bookmarks/page.tsx
+++ b/app/bookmarks/page.tsx
@@ -1,0 +1,10 @@
+export default function BookmarksPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Bookmarks</h1>
+      <p className="text-sm text-muted-foreground">
+        Save and manage favorite voice generations.
+      </p>
+    </div>
+  );
+}

--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Sidebar from '@/components/ui/Sidebar';
+import { useState } from 'react';
+import { Menu } from 'lucide-react';
+
+export default function ClientLayout({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div className="flex min-h-screen bg-background text-foreground">
+      <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((prev) => !prev)} />
+      <div className="flex w-full flex-col">
+        <header className="drag-region flex h-12 items-center gap-3 border-b border-border bg-secondary px-3">
+          <button
+            type="button"
+            className="no-drag rounded-md p-2 hover:bg-muted"
+            aria-label="Toggle sidebar"
+            onClick={() => setCollapsed((prev) => !prev)}
+          >
+            <Menu className="h-4 w-4" />
+          </button>
+          <div className="text-sm font-medium">Mint Speech</div>
+        </header>
+        <main className="flex-1 overflow-auto px-3 py-4">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,35 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 220 13% 9%;
+  --foreground: 220 13% 98%;
+  --primary: 220 90% 56%;
+  --secondary: 220 13% 15%;
+  --muted: 220 13% 15%;
+  --muted-foreground: 220 13% 60%;
+  --border: 220 13% 15%;
+  --accent: 220 13% 15%;
+  --destructive: 0 62.8% 30.6%;
+  --sidebar: 0 0% 10%;
+  --sidebar-foreground: 0 0% 95%;
+  --sidebar-primary: 220 90% 56%;
+  --sidebar-border: 220 13% 18%;
+}
+
+* {
+  border-color: hsl(var(--border));
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+.drag-region {
+  -webkit-app-region: drag;
+}
+
+.no-drag {
+  -webkit-app-region: no-drag;
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,10 @@
+export default function HelpPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Help & Documentation</h1>
+      <p className="text-sm text-muted-foreground">
+        Find onboarding guides, shortcut references, and troubleshooting tips.
+      </p>
+    </div>
+  );
+}

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,0 +1,10 @@
+export default function HistoryPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">History</h1>
+      <p className="text-sm text-muted-foreground">
+        Review and replay your recent text-to-speech generations.
+      </p>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import ClientLayout from './client-layout';
+
+export const metadata: Metadata = {
+  title: 'Mint Speech',
+  description: 'Premium neural text-to-speech for desktop'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ClientLayout>{children}</ClientLayout>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function HomePage() {
+  redirect('/reader');
+}

--- a/app/reader/page.tsx
+++ b/app/reader/page.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Play, Square, Bookmark } from 'lucide-react';
+import PlayerControls from '@/components/ui/PlayerControls';
+import VoicePicker from '@/components/ui/VoicePicker';
+
+export default function ReaderPage() {
+  const [text, setText] = useState('');
+  const [speed, setSpeed] = useState(1);
+  const [volume, setVolume] = useState(100);
+  const charCount = useMemo(() => text.length, [text]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <section className="rounded-lg border border-border bg-secondary p-6 shadow-sm">
+        <h1 className="text-2xl font-semibold">TTS Composer</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enter text, pick a voice, and generate premium neural speech.
+        </p>
+        <div className="mt-6 flex flex-col gap-4">
+          <textarea
+            className="min-h-[180px] w-full resize-none rounded-md border border-border bg-background p-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+            placeholder="Type or paste your script..."
+            value={text}
+            onChange={(event) => setText(event.target.value)}
+          />
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>{charCount} characters</span>
+            <button type="button" className="inline-flex items-center gap-2">
+              <Bookmark className="h-3.5 w-3.5" />
+              Save to bookmarks
+            </button>
+          </div>
+          <VoicePicker />
+          <PlayerControls
+            speed={speed}
+            volume={volume}
+            onSpeedChange={setSpeed}
+            onVolumeChange={setVolume}
+          />
+          <div className="flex flex-wrap gap-3">
+            <button className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-white">
+              <Play className="h-4 w-4" />
+              Generate & Play
+            </button>
+            <button className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2 text-sm">
+              <Square className="h-4 w-4" />
+              Stop
+            </button>
+          </div>
+        </div>
+      </section>
+      <section className="rounded-lg border border-border bg-secondary p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Subtitle Preview</h2>
+        <p className="mt-2 rounded-md border border-dashed border-border bg-background p-4 text-sm text-muted-foreground">
+          Subtitles will appear here during playback.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -1,0 +1,10 @@
+export default function RoadmapPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Roadmap</h1>
+      <p className="text-sm text-muted-foreground">
+        Follow planned features and progress updates synced from GitHub.
+      </p>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,10 @@
+export default function SettingsPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Settings</h1>
+      <p className="text-sm text-muted-foreground">
+        Configure preferences, integrations, and shortcuts.
+      </p>
+    </div>
+  );
+}

--- a/app/usage/page.tsx
+++ b/app/usage/page.tsx
@@ -1,0 +1,10 @@
+export default function UsagePage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Usage</h1>
+      <p className="text-sm text-muted-foreground">
+        Track usage metrics across providers and voices.
+      </p>
+    </div>
+  );
+}

--- a/app/voices/page.tsx
+++ b/app/voices/page.tsx
@@ -1,0 +1,10 @@
+export default function VoicesPage() {
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <h1 className="text-2xl font-semibold">Voices</h1>
+      <p className="text-sm text-muted-foreground">
+        Browse and preview the available voice catalog.
+      </p>
+    </div>
+  );
+}

--- a/components/ui/PlayerControls.tsx
+++ b/components/ui/PlayerControls.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import * as Slider from '@radix-ui/react-slider';
+
+type PlayerControlsProps = {
+  speed: number;
+  volume: number;
+  onSpeedChange: (value: number) => void;
+  onVolumeChange: (value: number) => void;
+};
+
+export default function PlayerControls({
+  speed,
+  volume,
+  onSpeedChange,
+  onVolumeChange
+}: PlayerControlsProps) {
+  return (
+    <div className="grid gap-4 rounded-md border border-border bg-background p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">Speed</span>
+        <span className="text-xs text-muted-foreground">{speed.toFixed(2)}x</span>
+      </div>
+      <Slider.Root
+        className="relative flex h-4 w-full touch-none items-center"
+        value={[speed]}
+        min={0.25}
+        max={4}
+        step={0.05}
+        onValueChange={(value) => onSpeedChange(value[0] ?? 1)}
+      >
+        <Slider.Track className="relative h-1 w-full grow rounded-full bg-muted">
+          <Slider.Range className="absolute h-full rounded-full bg-primary" />
+        </Slider.Track>
+        <Slider.Thumb className="block h-4 w-4 rounded-full bg-primary" />
+      </Slider.Root>
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">Volume</span>
+        <span className="text-xs text-muted-foreground">{volume}%</span>
+      </div>
+      <Slider.Root
+        className="relative flex h-4 w-full touch-none items-center"
+        value={[volume]}
+        min={0}
+        max={100}
+        step={1}
+        onValueChange={(value) => onVolumeChange(value[0] ?? 100)}
+      >
+        <Slider.Track className="relative h-1 w-full grow rounded-full bg-muted">
+          <Slider.Range className="absolute h-full rounded-full bg-primary" />
+        </Slider.Track>
+        <Slider.Thumb className="block h-4 w-4 rounded-full bg-primary" />
+      </Slider.Root>
+    </div>
+  );
+}

--- a/components/ui/Sidebar.tsx
+++ b/components/ui/Sidebar.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import {
+  BookMarked,
+  Headphones,
+  History,
+  LayoutDashboard,
+  MessageCircleQuestion,
+  Mic2,
+  Settings,
+  Sparkles
+} from 'lucide-react';
+
+const navItems = [
+  { href: '/reader', label: 'Reader', icon: Headphones },
+  { href: '/history', label: 'History', icon: History },
+  { href: '/bookmarks', label: 'Bookmarks', icon: BookMarked },
+  { href: '/usage', label: 'Usage', icon: LayoutDashboard },
+  { href: '/voices', label: 'Voices', icon: Mic2 },
+  { href: '/roadmap', label: 'Roadmap', icon: Sparkles },
+  { href: '/help', label: 'Help', icon: MessageCircleQuestion },
+  { href: '/settings', label: 'Settings', icon: Settings }
+];
+
+export default function Sidebar({
+  collapsed,
+  onToggle
+}: {
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <aside
+      className={cn(
+        'flex h-screen flex-col border-r border-border bg-[hsl(var(--sidebar))] text-[hsl(var(--sidebar-foreground))] transition-all',
+        collapsed ? 'w-16' : 'w-56'
+      )}
+    >
+      <div className="flex h-12 items-center justify-between px-3">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          <span className="rounded-md bg-[hsl(var(--sidebar-primary))] px-2 py-1 text-xs text-white">
+            MS
+          </span>
+          {!collapsed && <span>Mint Speech</span>}
+        </div>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="rounded-md px-2 py-1 text-xs text-[hsl(var(--sidebar-foreground))]/70 hover:text-[hsl(var(--sidebar-foreground))]"
+        >
+          {collapsed ? '»' : '«'}
+        </button>
+      </div>
+      <nav className="flex flex-1 flex-col gap-1 px-2 py-3 text-sm">
+        {navItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                'flex items-center gap-3 rounded-md px-3 py-2 text-[hsl(var(--sidebar-foreground))]/80 transition hover:bg-[hsl(var(--sidebar-border))]',
+                collapsed && 'justify-center px-0'
+              )}
+            >
+              <Icon className="h-4 w-4" />
+              {!collapsed && <span>{item.label}</span>}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/components/ui/VoicePicker.tsx
+++ b/components/ui/VoicePicker.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+const providers = [
+  { id: 'edgetts', label: 'Edge TTS' },
+  { id: 'gemini', label: 'Gemini' },
+  { id: 'elevenlabs', label: 'ElevenLabs' }
+];
+
+export default function VoicePicker() {
+  const [provider, setProvider] = useState('edgetts');
+  const [voice, setVoice] = useState('Microsoft Jenny');
+
+  return (
+    <div className="grid gap-3 rounded-md border border-border bg-background p-4">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-muted-foreground">Provider</label>
+        <div className="flex gap-2">
+          {providers.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setProvider(item.id)}
+              className={`rounded-md px-3 py-2 text-xs font-medium transition ${
+                provider === item.id
+                  ? 'bg-primary text-white'
+                  : 'border border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-muted-foreground">Voice</label>
+        <button
+          type="button"
+          className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm"
+          aria-label="Select voice"
+        >
+          <span>{voice}</span>
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,0 +1,45 @@
+import { app, BrowserWindow, globalShortcut } from 'electron';
+import path from 'node:path';
+
+let mainWindow: BrowserWindow | null = null;
+
+const createWindow = () => {
+  mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    },
+    titleBarStyle: process.platform === 'darwin' ? 'hidden' : 'default',
+    frame: process.platform !== 'darwin'
+  });
+
+  const url = process.env.NEXT_DEV_SERVER_URL ?? 'http://localhost:3000';
+  void mainWindow.loadURL(url);
+};
+
+app.whenReady().then(() => {
+  createWindow();
+
+  globalShortcut.register('CommandOrControl+Shift+D', () => {
+    if (!mainWindow) return;
+    if (mainWindow.isVisible()) {
+      mainWindow.hide();
+    } else {
+      mainWindow.show();
+    }
+  });
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  globalShortcut.unregisterAll();
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,7 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('mintSpeech', {
+  onClipboardTts: (handler: (text: string) => void) => {
+    ipcRenderer.on('clipboard-tts', (_event, text) => handler(text));
+  }
+});

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { cn } from '../utils';
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('dedupes tailwind classes', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4');
+  });
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "mint-speech",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "lint": "next lint",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "dependencies": {
+    "@radix-ui/react-slider": "^1.1.2",
+    "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tabs": "^1.0.4",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "edge-tts-universal": "^1.3.2",
+    "lucide-react": "^0.432.0",
+    "next": "15.0.0-rc.0",
+    "react": "19.0.0-rc-02c0e824-20240828",
+    "react-dom": "19.0.0-rc-02c0e824-20240828",
+    "tailwind-merge": "^3.3.1",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.19",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "15.0.0-rc.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: 'hsl(var(--primary))',
+        secondary: 'hsl(var(--secondary))',
+        muted: 'hsl(var(--muted))',
+        'muted-foreground': 'hsl(var(--muted-foreground))',
+        border: 'hsl(var(--border))',
+        accent: 'hsl(var(--accent))',
+        destructive: 'hsl(var(--destructive))'
+      }
+    }
+  },
+  plugins: [require('tailwindcss-animate')]
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/types/electron-api.ts
+++ b/types/electron-api.ts
@@ -1,0 +1,9 @@
+export type MintSpeechApi = {
+  onClipboardTts: (handler: (text: string) => void) => void;
+};
+
+declare global {
+  interface Window {
+    mintSpeech?: MintSpeechApi;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['lib/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
### Motivation
- Provide a starting scaffold for the Mint Speech desktop application combining a Next.js App Router frontend with Electron hosting and a modern UI layout.
- Establish core routes, pages, and UI components so TTS features and provider integrations can be implemented incrementally.
- Add placeholder server endpoints to define where provider proxies (Edge TTS, Gemini, ElevenLabs) and roadmap fetchers will be implemented.
- Create baseline project configuration (TypeScript, Tailwind, PostCSS, dev scripts) to enable local development and iteration.

### Description
- Add a Next.js app skeleton with pages and routing including `app/reader`, `app/history`, `app/bookmarks`, `app/voices`, `app/usage`, `app/settings`, `app/help`, `app/roadmap`, and root layout `app/layout.tsx`/`app/client-layout.tsx`.
- Implement core UI pieces: `components/ui/Sidebar.tsx`, `components/ui/VoicePicker.tsx`, and `components/ui/PlayerControls.tsx`, plus global styles at `app/globals.css` and utility `lib/utils.ts`.
- Add placeholder API routes under `app/api/{edgetts,gemini,elevenlabs,roadmap}/route.ts` returning `501`, and Electron stubs `electron/main.ts` and `electron/preload.ts` with window creation, a global shortcut, and a context bridge.
- Add project configuration and tooling files including `package.json`, `tsconfig.json`, `next.config.mjs`, `tailwind.config.ts`, `postcss.config.mjs`, and `next-env.d.ts`.

### Testing
- No automated tests were executed during this scaffold change.
- The repository includes `vitest` as a dev dependency but `yarn test` / `bun` were not run in this rollout.
- No build or runtime verification was performed in the current environment.
- To validate locally, install dependencies with `yarn install` or `bun install` and start development with `yarn dev` (or the equivalent Bun command).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea0014ce0832a946f384bb68e9ca4)